### PR TITLE
Rewrite Redis manager

### DIFF
--- a/manager/redis/manager_redis.go
+++ b/manager/redis/manager_redis.go
@@ -3,9 +3,9 @@ package redis
 import (
 	"encoding/json"
 
-	"github.com/pkg/errors"
 	"github.com/go-redis/redis"
-	. "github.com/ory-am/ladon"
+	. "github.com/ory/ladon"
+	"github.com/pkg/errors"
 )
 
 // RedisManager is a redis implementation of Manager to store policies persistently.

--- a/manager/redis/manager_redis.go
+++ b/manager/redis/manager_redis.go
@@ -51,7 +51,7 @@ func (m *RedisManager) Create(policy Policy) error {
 }
 
 // GetAll retrieves a all policy.
-func (m *RedisManager) GetAll() (Policies, error) {
+func (m *RedisManager) GetAll(limit int64, offset int64) (Policies, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -98,6 +98,10 @@ func (m *RedisManager) FindRequestCandidates(r *Request) (Policies, error) {
 	}
 
 	return ps, nil
+}
+
+func (m *RedisManager) Update(policy Policy) error {
+	return nil
 }
 
 func redisUnmarshalPolicy(policy []byte) (Policy, error) {

--- a/manager/redis/manager_redis.go
+++ b/manager/redis/manager_redis.go
@@ -1,13 +1,31 @@
 // The (new) redis manager is intended to look like the officially supported memory manager.
+// We take the tradeoff for slower inserts and deletions to make it easier to find applicable policies.
 package redis
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/go-redis/redis"
 	. "github.com/ory/ladon"
 	"github.com/pkg/errors"
 )
+
+var (
+	ErrPolicyExists  = errors.New("Policy exists")
+	ErrBadConversion = errors.New("Could not convert policy from redis")
+)
+
+const (
+	prefixPolicy   = "policy"
+	prefixResource = "resource"
+	prefixSubject  = "subject"
+)
+
+// Just returns strings.Join(vals, "_") for creating redis keys
+func prefixKey(vals ...string) string {
+	return strings.Join(vals, "_")
+}
 
 // RedisManager is a redis implementation of Manager to store policies persistently.
 type RedisManager struct {
@@ -17,24 +35,21 @@ type RedisManager struct {
 
 // NewRedisManager initializes a new RedisManager with no policies
 func NewRedisManager(db *redis.Client, keyPrefix string) *RedisManager {
+	if keyPrefix == "" {
+		keyPrefix = "ladon"
+	}
+
 	return &RedisManager{
 		db:        db,
 		keyPrefix: keyPrefix,
 	}
 }
 
-var (
-	ErrPolicyExists  = errors.New("Policy exists")
-	ErrBadConversion = errors.New("Could not convert policy from redis")
-)
-
-func (m *RedisManager) getKey(key string) string {
-	return m.keyPrefix + key
-}
-
-// Create a new policy to RedisManager
+// Create a new policy in Redis. It will create a single key for the policy itself,
+// and for each subject and resource the policy will also exist in a hashmap.
 func (m *RedisManager) Create(policy Policy) error {
-	key := m.getKey(policy.GetID())
+	// Make sure that the key doesn't already exist
+	key := prefixKey(m.keyPrefix, prefixPolicy, policy.GetID())
 	if err := m.db.Get(key).Err(); err == nil {
 		return ErrPolicyExists
 	}
@@ -44,17 +59,41 @@ func (m *RedisManager) Create(policy Policy) error {
 		return err
 	}
 
+	// Set the policy key
 	cmd := m.db.Set(key, p, 0)
 
 	if err := cmd.Err(); err != nil {
 		return err
+	}
+
+	// Put this policy in the hashmap for each resource
+	for _, v := range policy.GetResources() {
+		hmkey := prefixKey(m.keyPrefix, prefixResource, v)
+		field := policy.GetID()
+		if err := m.db.HMSet(hmkey, map[string]interface{}{
+			field: p,
+		}).Err(); err != nil {
+			return err
+		}
+	}
+
+	// Put this policy in the hashmap for each subject
+	for _, v := range policy.GetSubjects() {
+		hmkey := prefixKey(m.keyPrefix, prefixSubject, v)
+		field := policy.GetID()
+		if err := m.db.HMSet(hmkey, map[string]interface{}{
+			field: p,
+		}).Err(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 // GetAll retrieves all policies. (Equivelant of db.keys + db.Mget)
 func (m *RedisManager) GetAll(limit int64, offset int64) (Policies, error) {
-	keyscmd := m.db.Keys(m.getKey("*"))
+	key := prefixKey(m.keyPrefix, prefixPolicy, "*")
+	keyscmd := m.db.Keys(key)
 	if err := keyscmd.Err(); err != nil {
 		return nil, err
 	}
@@ -95,7 +134,7 @@ func (m *RedisManager) GetAll(limit int64, offset int64) (Policies, error) {
 // Get retrieves a policy.
 func (m *RedisManager) Get(id string) (Policy, error) {
 	var (
-		key    = m.getKey(id)
+		key    = prefixKey(m.keyPrefix, prefixPolicy, id)
 		cmd    = m.db.Get(key)
 		policy = &DefaultPolicy{}
 	)
@@ -116,12 +155,41 @@ func (m *RedisManager) Get(id string) (Policy, error) {
 
 // Delete removes a policy.
 func (m *RedisManager) Delete(id string) error {
-	key := m.getKey(id)
-	if err := m.db.Get(key).Err(); err != nil {
+	key := prefixKey(m.keyPrefix, prefixPolicy, id)
+	getCmd := m.db.Get(key)
+	if err := getCmd.Err(); err != nil {
 		return ErrNotFound
 	}
+	policy := &DefaultPolicy{}
+	res, err := getCmd.Result()
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal([]byte(res), policy); err != nil {
+		return errors.Wrap(ErrBadConversion, err.Error())
+	}
+
 	if err := m.db.Del(key).Err(); err != nil {
 		return err
+	}
+
+	// Put this policy in the hashmap for each resource
+	for _, v := range policy.GetResources() {
+		hmkey := prefixKey(m.keyPrefix, prefixResource, v)
+		field := policy.GetID()
+		if err := m.db.HDel(hmkey, field).Err(); err != nil {
+			return err
+		}
+	}
+
+	// Put this policy in the hashmap for each subject
+	for _, v := range policy.GetSubjects() {
+		hmkey := prefixKey(m.keyPrefix, prefixSubject, v)
+		field := policy.GetID()
+		if err := m.db.HDel(hmkey, field).Err(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -131,50 +199,95 @@ func (m *RedisManager) Delete(id string) error {
 // a set that exactly matches the request, or a superset of it. If an error occurs, it returns nil and
 // the error.
 func (m *RedisManager) FindRequestCandidates(r *Request) (Policies, error) {
-	keyscmd := m.db.Keys(m.getKey("*"))
-	if err := keyscmd.Err(); err != nil {
+	policies := Policies{}
+	var (
+		rKey    = prefixKey(m.keyPrefix, prefixResource, r.Resource)
+		sKey    = prefixKey(m.keyPrefix, prefixSubject, r.Subject)
+		rGetCmd = m.db.HGetAll(rKey)
+		sGetCmd = m.db.HGetAll(sKey)
+	)
+	if err := rGetCmd.Err(); err != nil {
+		return nil, err
+	}
+	if err := sGetCmd.Err(); err != nil {
 		return nil, err
 	}
 
-	keys, err := keyscmd.Result()
+	rPolicies, err := rGetCmd.Result()
+	if err != nil {
+		return nil, err
+	}
+	sPolicies, err := sGetCmd.Result()
 	if err != nil {
 		return nil, err
 	}
 
-	mgetcmd := m.db.MGet(keys...)
-	if err := mgetcmd.Err(); err != nil {
-		return nil, err
-	}
-
-	values := mgetcmd.Val()
-
-	policies := make(Policies, len(values))
-	for i, v := range values {
+	for _, v := range rPolicies {
 		p := &DefaultPolicy{}
-		b := []byte(v.(string))
+		b := []byte(v)
 		// if !ok {
 		// 	return nil, errors.Wrapf(ErrBadConversion, "value %+v is not a byte array", v)
 		// }
 		if err := json.Unmarshal(b, p); err != nil {
 			return nil, errors.Wrap(ErrBadConversion, err.Error())
 		}
-		policies[i] = p
+		policies = append(policies, p)
+	}
+
+	for _, v := range sPolicies {
+		p := &DefaultPolicy{}
+		b := []byte(v)
+		// if !ok {
+		// 	return nil, errors.Wrapf(ErrBadConversion, "value %+v is not a byte array", v)
+		// }
+		if err := json.Unmarshal(b, p); err != nil {
+			return nil, errors.Wrap(ErrBadConversion, err.Error())
+		}
+		policies = append(policies, p)
 	}
 
 	return policies, nil
 }
 
 func (m *RedisManager) Update(policy Policy) error {
-	key := m.getKey(policy.GetID())
+	// Make sure that the key doesn't already exist
+	key := prefixKey(m.keyPrefix, prefixPolicy, policy.GetID())
 	if err := m.db.Get(key).Err(); err != nil {
 		return ErrNotFound
 	}
-	b, err := json.Marshal(policy)
+
+	p, err := json.Marshal(policy)
 	if err != nil {
-		return errors.Wrap(ErrBadConversion, err.Error())
-	}
-	if err := m.db.Set(key, b, 0).Err(); err != nil {
 		return err
+	}
+
+	// Set the policy key
+	cmd := m.db.Set(key, p, 0)
+
+	if err := cmd.Err(); err != nil {
+		return err
+	}
+
+	// Put this policy in the hashmap for each resource
+	for _, v := range policy.GetResources() {
+		hmkey := prefixKey(m.keyPrefix, prefixResource, v)
+		field := policy.GetID()
+		if err := m.db.HMSet(hmkey, map[string]interface{}{
+			field: p,
+		}).Err(); err != nil {
+			return err
+		}
+	}
+
+	// Put this policy in the hashmap for each subject
+	for _, v := range policy.GetSubjects() {
+		hmkey := prefixKey(m.keyPrefix, prefixSubject, v)
+		field := policy.GetID()
+		if err := m.db.HMSet(hmkey, map[string]interface{}{
+			field: p,
+		}).Err(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/manager/redis/manager_redis_test.go
+++ b/manager/redis/manager_redis_test.go
@@ -194,14 +194,18 @@ func TestFindRequestCandidate(t *testing.T) {
 	policies := Policies{
 		&DefaultPolicy{
 			ID:         "test-policy-1",
+			Subjects:   []string{"ex1", "ex2"},
+			Resources:  []string{"exr1", "exr2"},
 			Conditions: Conditions{},
 		},
 		&DefaultPolicy{
 			ID:         "test-policy-2",
+			Subjects:   []string{"ex1", "ex2"},
 			Conditions: Conditions{},
 		},
 		&DefaultPolicy{
 			ID:         "test-policy-3",
+			Subjects:   []string{"ex3", "ex4"},
 			Conditions: Conditions{},
 		},
 	}
@@ -212,21 +216,21 @@ func TestFindRequestCandidate(t *testing.T) {
 		}
 	}
 
-	p, err := m.FindRequestCandidates(nil)
+	p, err := m.FindRequestCandidates(&Request{
+		Resource: "exr1",
+		Action:   "get",
+		Subject:  "ex1",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, v := range policies {
-		if contains(p, v) != true {
-			t.Fatalf("Policy %+v not found in original", v)
-		}
+	if contains(p, policies[0]) != true {
+		t.Fatalf("Policy %+v not found in result of FindRequestCandidates", policies[0])
 	}
 
-	for _, v := range policies {
-		if contains(p, v) != true {
-			t.Fatalf("Policy %+v not found in returned policies", v)
-		}
+	if contains(p, policies[2]) {
+		t.Fatalf("Policy %+v was not expected from FindRequestCandidates", policies[2])
 	}
 }
 

--- a/manager/redis/manager_redis_test.go
+++ b/manager/redis/manager_redis_test.go
@@ -14,6 +14,15 @@ import (
 
 var db *redis.Client
 
+func contains(s []ladon.Policy, p ladon.Policy) bool {
+	for _, v := range s {
+		if cmp.Equal(v, p) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestMain(m *testing.M) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -111,4 +120,106 @@ func TestGet(t *testing.T) {
 			t.Fatal("Attempting to get a policy that doesn't exist should return an error")
 		}
 	})
+}
+
+func TestUpdate(t *testing.T) {
+	m := NewRedisManager(db, "update")
+
+	t.Run("Successfully update a policy", func(t *testing.T) {
+		// Some weirdness with json.Marshal requires us to initialize Conditions for this test
+		policy := &ladon.DefaultPolicy{
+			ID:         "example-policy-1",
+			Subjects:   []string{"1", "2"},
+			Conditions: ladon.Conditions{},
+		}
+		err := m.Create(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		policy.Subjects = []string{"2", "3", "4"}
+		if err := m.Update(policy); err != nil {
+			t.Fatal(err)
+		}
+
+		u, err := m.Get(policy.GetID())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if cmp.Equal(u, policy) != true {
+			t.Fatalf("Unexpected policy from 'Get' after 'Update'\n%s", cmp.Diff(u, policy))
+		}
+	})
+
+	t.Run("Attempt to update a policy that doesn't exist", func(t *testing.T) {
+		if err := m.Update(&ladon.DefaultPolicy{
+			ID: "this policy does not exist",
+		}); err != ladon.ErrNotFound {
+			t.Fatal("No error returned when attempting to update a policy that does not exist")
+		}
+	})
+}
+
+func TestDelete(t *testing.T) {
+	m := NewRedisManager(db, "delete")
+
+	t.Run("Successfully delete a policy", func(t *testing.T) {
+		// Some weirdness with json.Marshal requires us to initialize Conditions for this test
+		policy := &ladon.DefaultPolicy{
+			ID:         "example-policy-1",
+			Subjects:   []string{"1", "2"},
+			Conditions: ladon.Conditions{},
+		}
+		err := m.Create(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := m.Delete(policy.GetID()); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Attempt to delete a policy that does not exist", func(t *testing.T) {
+		if err := m.Delete("this policy does not exist"); err != ladon.ErrNotFound {
+			t.Fatal("No error returned when attempting to delete a policy that does not exist")
+		}
+	})
+}
+
+func TestFindRequestCandidate(t *testing.T) {
+	m := NewRedisManager(db, "find")
+
+	policies := ladon.Policies{
+		&ladon.DefaultPolicy{
+			ID:         "test-policy-1",
+			Conditions: ladon.Conditions{},
+		},
+		&ladon.DefaultPolicy{
+			ID:         "test-policy-2",
+			Conditions: ladon.Conditions{},
+		},
+		&ladon.DefaultPolicy{
+			ID:         "test-policy-3",
+			Conditions: ladon.Conditions{},
+		},
+	}
+
+	for _, v := range policies {
+		if err := m.Create(v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	p, err := m.FindRequestCandidates(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, v := range policies {
+		if contains(p, v) != true {
+			t.Fatalf("Policy %+v not found", v)
+		}
+	}
 }

--- a/manager/redis/manager_redis_test.go
+++ b/manager/redis/manager_redis_test.go
@@ -1,0 +1,114 @@
+package redis
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/go-redis/redis"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ory/ladon"
+	"gopkg.in/ory-am/dockertest.v3"
+)
+
+var db *redis.Client
+
+func TestMain(m *testing.M) {
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		log.Fatalf("Could not connect to docker: %s", err)
+	}
+
+	// pulls an image, creates a container based on it and runs it
+	resource, err := pool.Run("redis", "3.2.11", nil)
+	if err != nil {
+		log.Fatalf("Could not start resource: %s", err)
+	}
+	settings, err := redis.ParseURL(fmt.Sprintf("redis://localhost:%s", resource.GetPort("6379/tcp")))
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	db = redis.NewClient(settings)
+
+	// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
+	if err := pool.Retry(func() error {
+		_, err := db.Ping().Result()
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		log.Fatalf("Could not connect to docker: %s", err)
+	}
+
+	code := m.Run()
+
+	// You can't defer this because os.Exit doesn't care for defer
+	if err := pool.Purge(resource); err != nil {
+		log.Fatalf("Could not purge resource: %s", err)
+	}
+
+	os.Exit(code)
+}
+
+func TestCreate(t *testing.T) {
+	m := NewRedisManager(db, "create")
+
+	t.Run("Successfully create a single resource", func(t *testing.T) {
+		policy := &ladon.DefaultPolicy{
+			ID: "example-policy-1",
+		}
+		err := m.Create(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Error when creating duplicate policies", func(t *testing.T) {
+		policy := &ladon.DefaultPolicy{
+			ID: "example-policy-2",
+		}
+		err := m.Create(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = m.Create(policy)
+		if err != ErrPolicyExists {
+			t.Fatal("No error returned when creating duplicate policies")
+		}
+	})
+	// Create the same resource twice should return an error
+}
+
+func TestGet(t *testing.T) {
+	m := NewRedisManager(db, "get")
+
+	t.Run("Successfully retrieve a single policy", func(t *testing.T) {
+		// Some weirdness with json.Marshal requires us to initialize Conditions for this test
+		policy := &ladon.DefaultPolicy{
+			ID:         "example-policy-1",
+			Subjects:   []string{"1", "2"},
+			Conditions: ladon.Conditions{},
+		}
+		err := m.Create(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, err := m.Get(policy.GetID())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if cmp.Equal(policy, p) != true {
+			t.Fatalf("Unexpected policy.\n%s", cmp.Diff(policy, p))
+		}
+	})
+
+	t.Run("Attempt to retrieve a non-existent policy", func(t *testing.T) {
+		_, err := m.Get("policy that doesn't exist")
+		if err != ladon.ErrNotFound {
+			t.Fatal("Attempting to get a policy that doesn't exist should return an error")
+		}
+	})
+}


### PR DESCRIPTION
1. I really did not like the Redis implementation that existed; not only because it was half-finished, but because it dropped every policy into a single hashmap key rather than taking advantage of the key/value storage aspect of Redis.

2. I finished the unimplemented functions

3. There was a really bad memory leak in `redisUnmarshalPolicy`. I'm still struggling to find out why exactly but my implementation seemed to fix this.

4. I added some basic tests just for sanity.

Lastly, if `ladon.DefaultPolicy` implemented [`BinaryMarshaler`](https://golang.org/pkg/encoding/#BinaryMarshaler) and [`BinaryUnmarshaler`](https://golang.org/pkg/encoding/#BinaryUnmarshaler) then we could avoid a lot of to-and-from JSON overhead.

I think Redis is honestly the best candidate for a storage backend for Ladon. We ran into tons of performance issues with multiple unique permission checks when using Postgres. In my opinion, Redis should have more official support.