### PR TITLE
Add FindPoliciesForSubject & FindPoliciesForResource implement for Redis Manager

### DIFF
--- a/manager/redis/manager_redis.go
+++ b/manager/redis/manager_redis.go
@@ -205,6 +205,7 @@ func (m *RedisManager) FindPoliciesForResource(resource string) (Policies, error
 		rKey    = prefixKey(m.keyPrefix, prefixResource, resource)
 		rGetCmd = m.db.HGetAll(rKey)
 	)
+
 	if err := rGetCmd.Err(); err != nil {
 		return nil, err
 	}
@@ -223,7 +224,7 @@ func (m *RedisManager) FindPoliciesForResource(resource string) (Policies, error
 		policies = append(policies, p)
 	}
 
-	return nil, nil
+	return policies, nil
 }
 
 // FindPoliciesForSubject returns policies that could match the subject. It either returns

--- a/manager/redis/manager_redis.go
+++ b/manager/redis/manager_redis.go
@@ -195,6 +195,68 @@ func (m *RedisManager) Delete(id string) error {
 	return nil
 }
 
+// FindPoliciesForResource returns policies that could match the resource. It either returns
+// a set of policies that apply to the resource, or a superset of it.
+// If an error occurs, it returns nil and the error.
+func (m *RedisManager) FindPoliciesForResource(resource string) (Policies, error) {
+	policies := Policies{}
+
+	var (
+		rKey    = prefixKey(m.keyPrefix, prefixResource, resource)
+		rGetCmd = m.db.HGetAll(rKey)
+	)
+	if err := rGetCmd.Err(); err != nil {
+		return nil, err
+	}
+
+	rPolicies, err := rGetCmd.Result()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range rPolicies {
+		p := &DefaultPolicy{}
+		b := []byte(v)
+		if err := json.Unmarshal(b, p); err != nil {
+			return nil, errors.Wrap(ErrBadConversion, err.Error())
+		}
+		policies = append(policies, p)
+	}
+
+	return nil, nil
+}
+
+// FindPoliciesForSubject returns policies that could match the subject. It either returns
+// a set of policies that applies to the subject, or a superset of it.
+// If an error occurs, it returns nil and the error.
+func (m *RedisManager) FindPoliciesForSubject(subject string) (Policies, error) {
+	policies := Policies{}
+
+	var (
+		sKey    = prefixKey(m.keyPrefix, prefixSubject, subject)
+		sGetCmd = m.db.HGetAll(sKey)
+	)
+	if err := sGetCmd.Err(); err != nil {
+		return nil, err
+	}
+
+	sPolicies, err := sGetCmd.Result()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range sPolicies {
+		p := &DefaultPolicy{}
+		b := []byte(v)
+		if err := json.Unmarshal(b, p); err != nil {
+			return nil, errors.Wrap(ErrBadConversion, err.Error())
+		}
+		policies = append(policies, p)
+	}
+
+	return policies, nil
+}
+
 // FindRequestCandidates returns candidates that could match the request object. It either returns
 // a set that exactly matches the request, or a superset of it. If an error occurs, it returns nil and
 // the error.

--- a/manager/redis/manager_redis_test.go
+++ b/manager/redis/manager_redis_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/ory/ladon"
-	"gopkg.in/ory-am/dockertest.v3"
+	dockertest "gopkg.in/ory-am/dockertest.v3"
 )
 
 var db *redis.Client
@@ -231,6 +231,62 @@ func TestFindRequestCandidate(t *testing.T) {
 
 	if contains(p, policies[2]) {
 		t.Fatalf("Policy %+v was not expected from FindRequestCandidates", policies[2])
+	}
+}
+
+func TestFindPoliciesForResource(t *testing.T) {
+	m := NewRedisManager(db, "findResource")
+
+	policies := Policies{
+		&DefaultPolicy{
+			ID:         "test-policy-1",
+			Subjects:   []string{"ex1", "ex2"},
+			Resources:  []string{"exr1", "exr2"},
+			Conditions: Conditions{},
+		},
+	}
+
+	for _, p := range policies {
+		if err := m.Create(p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	p, err := m.FindPoliciesForResource("exr1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(p) == 0 || contains(policies, p[0]) == false {
+		t.Fatalf("Policy %+v not found in result of FindRequestCandidates", p[0])
+	}
+}
+
+func TestFindPoliciesForSubject(t *testing.T) {
+	m := NewRedisManager(db, "FindPoliciesForSubject")
+
+	policies := Policies{
+		&DefaultPolicy{
+			ID:         "test-policy-1",
+			Subjects:   []string{"ex1", "ex2"},
+			Resources:  []string{"exr1", "exr2"},
+			Conditions: Conditions{},
+		},
+	}
+
+	for _, p := range policies {
+		if err := m.Create(p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	p, err := m.FindPoliciesForSubject("ex1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(p) == 0 || contains(policies, p[0]) == false {
+		t.Fatalf("Policy %+v not found in result of TestFindPoliciesForSubject", p[0])
 	}
 }
 


### PR DESCRIPTION
I implemented `FindPoliciesForSubject` and `FindPoliciesForResource` methods for Redis Manager, so we can use Redis to persist Ladon policy .